### PR TITLE
Add Ruby 2.3.1 to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
+  - 2.3.1
 before_install: "gem update bundler"
 script:
   - "bundle exec rake"


### PR DESCRIPTION
Would love to know this works against 2.3.1 (I don't think Travis support `2.3` syntax yet).