### PR TITLE
Add support for ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 rvm:
   - 2.5
   - 2.6
+  - 2.7
 before_install: "gem update bundler"
 script:
   - "bundle exec rake"

--- a/damerau-levenshtein.gemspec
+++ b/damerau-levenshtein.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.push File.expand_path("lib", __dir__)
 require "damerau-levenshtein/version"
 
 Gem::Specification.new do |s|
-  s.required_ruby_version = "~> 2.5"
+  s.required_ruby_version = ">= 2.5"
   s.name = "damerau-levenshtein"
   s.version = DamerauLevenshtein::VERSION
   s.homepage = "https://github.com/GlobalNamesArchitecture/damerau-levenshtein"


### PR DESCRIPTION
Add ruby 2.7 as a target to Travis CI.
Change the required ruby version to >= 2.5 (as mentioned in #17).